### PR TITLE
Prevent setup race condition.

### DIFF
--- a/ofrestapi/__init__.py
+++ b/ofrestapi/__init__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.1.1'
-
 from ofrestapi.users import Users
 from ofrestapi.muc import Muc
 from ofrestapi.system import System
 from ofrestapi.groups import Groups
 from ofrestapi.sessions import Sessions
 from ofrestapi.messages import Messages
+
+import pkg_resources
+__version__ = pkg_resources.require("openfire-restapi")[0].version

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,14 @@
 
 from setuptools import setup
 
-from ofrestapi import __version__
-
-
 setup(
     name='openfire-restapi',
-    version=__version__,
-    description=u'A python client for Openfire’s REST API Plugin',
+    version='0.1.1',
+    description=u"A python client for Openfire's REST API Plugin",
     license="GPL-3",
     author='Sergey Fedotov (seamus-45)',
     author_email='sr.fido@gmail.com',
     url='https://github.com/seamus-45/openfire-restapi',
-    packages=['ofrestapi']
+    packages=['ofrestapi'],
+    install_requires=['requests>=2.9.1'],
 )


### PR DESCRIPTION
Allows setup to install requests instead of importing version and failing due to the missing requirement.

Will prevent more installation issues like https://github.com/R4stl1n/allianceauth/issues/609